### PR TITLE
ADD: makefile 추가 (#19)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 main
+main.o
+set_avl.o

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+CC = g++
+CXXFLAGS = -Wall -O2
+OBJS = main.o set_avl.o
+
+.PHONY: clean
+clean:
+		rm -f ${OBJS} main
+
+set_avl.o: set_avl.h set_avl.cc
+		${CC} ${CXXFLAGS} -c set_avl.cc
+
+main.o: set_avl.h main.cc
+		${CC} ${CXXFLAGS} -c main.cc
+
+main: ${OBJS}
+		${CC} ${CXXFLAGS} ${OBJS} -o main

--- a/main.cc
+++ b/main.cc
@@ -6,7 +6,7 @@
 
 int main()
 {
-    SetAVL* set = new SetAVL();
+    SetAVL set;
     
     return 0;
 }

--- a/main.cc
+++ b/main.cc
@@ -1,9 +1,12 @@
 // 라이선스
 
+#include "set_avl.h"
+
 #include <iostream>
 
 int main()
 {
-    std::cout << "Hello, World\n";
+    SetAVL* set = new SetAVL();
+    
     return 0;
 }

--- a/node.h
+++ b/node.h
@@ -7,11 +7,8 @@
 class Node
 {
 public:
-    virtual ~Node() = 0;
+    virtual ~Node() {}
     virtual int GetNum() const = 0;
 };
-
-// Node 클래스의 소멸자 정의
-Node::~Node() {}
 
 #endif

--- a/set.h
+++ b/set.h
@@ -7,7 +7,7 @@
 class Set
 {
 public:
-    virtual ~Set() = 0;
+    virtual ~Set() {}
 
     // Basic 기능
     // key를 root로 하는 subtree에서 최솟값을 갖는 node의 값과 depth를 출력

--- a/set_avl.cc
+++ b/set_avl.cc
@@ -23,7 +23,7 @@ int SetAVL::Find(const int key)
 }
 
 // num을 삽입하고 해당 node의 depth를 출력
-void Insert(const int num)
+void SetAVL::Insert(const int num)
 {
     
 }


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- feature/#19

🌱 작업한 내용
- Makefile 추가
    - set_avl.cc, set_avl.h을 통해 set_avl.o 파일 생성
    - main.cc, set_avl.h을 통해 main.o 파일 생성
    - main.o, set_avl.o 파일을 통해 실행 파일 main 생성
    - **make main**을 입력하는 것으로 **compile**을 할 수 있음
    - **make clean**을 입력하는 것으로 **main.o, set_avl.o, main을 삭제**할 수 있음
    - compile 진행 시 아래와 같은 옵션 추가
        - -Wall --> 모든 컴파일 경고를 출력
        - -O2 --> 최적화 레벨 2
- .gitignore 내용 추가
    - make main 입력 시 object 파일인 main.o, set_avl.o와 실행 파일인 main이 생성됨 
    - 이러한 파일은 굳이 github에 올릴 필요가 없다고 판단하여 .gitignore에 추가함
- main.cpp 파일명을 **main.cc**로 변경
- main.cc에 #include "set_avl.h" 추가 및 main 함수에 SetAVL 객체 생성 코드 추가
- node.h, set.h에 있는 가상 소멸자(virtual destructor)를 inline 형식으로 정의

## 📸 스크린샷

make main 입력 후 ./main을 통해 실행할 수 있음

![20231123 Makefile 실행 후 2](https://github.com/OpenSourceProgramming/INHA_OSAP_004_Froyo/assets/79794123/e560ad4a-88fd-4073-9765-d31eee52f5c5)

![20231123 Makefile 실행](https://github.com/OpenSourceProgramming/INHA_OSAP_004_Froyo/assets/79794123/06e5c5f3-4f50-4fce-b5d3-5fcb0cf91ac0)

make clean 입력 시 main.o, set_avl.o, main이 삭제됨

![20231123 make clean 실행 1](https://github.com/OpenSourceProgramming/INHA_OSAP_004_Froyo/assets/79794123/ff140c2e-2cc5-4394-b3e7-ed2df4069ce1)


## 📮 관련 이슈
- Resolved: #19
