### PR TITLE
Fix/Maximum 함수 버그 수정 #31

### DIFF
--- a/set_avl.cc
+++ b/set_avl.cc
@@ -37,7 +37,7 @@ void SetAVL::Maximum(const int key)
     {
         node = node->GetRight();
     }
-    std::cout << " " << node->GetNum() << " " << Find(node->GetNum());
+    std::cout << node->GetNum() << " " << Find(node->GetNum());
 }
 
 // 해당 key를 가지고 있는 node의 depth를 return

--- a/set_avl.cc
+++ b/set_avl.cc
@@ -24,12 +24,20 @@ void SetAVL::Maximum(const int key)
         else
             node = node->GetRight();
     }
+
+    // Set에 존재하지 않는 원소에 대한 처리
+    if(node == nullptr)
+    {
+        std::cout << "-1, -1" << std::endl;
+        return;
+    }
+    
     // subtree에서 최댓값을 갖는 node찾기
     while(node != nullptr && node->GetRight() != nullptr)
     {
         node = node->GetRight();
     }
-    std::cout << "key : " << node->GetNum() << ", depth : " << Find(key);
+    std::cout << " " << node->GetNum() << " " << Find(node->GetNum());
 }
 
 // 해당 key를 가지고 있는 node의 depth를 return


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- fix/#35 

🌱 작업한 내용
- depth가 잘못 출력되는 현상 수정
- Set에 존재하지 않는 원소에 대해 Maximum() 함수를 호출했을 때 노드의 값과 depth 값이 각각 -1이 출력되도록 수정

## 📸 스크린샷
![image](https://github.com/OpenSourceProgramming/INHA_OSAP_004_Froyo/assets/115926900/1f1dea30-aee1-4b9e-b8ae-65a8cf4bab7a)


## 📮 관련 이슈
- Resolved: #35 
