### PR TITLE
feat: 구글테스트 환경 구축, Insert 함수 return type 변경 (#33)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,16 @@ project(
 # 옵션 설정
 set (CMAKE_CXX_FLAGS "-O2 -Wall")
 
+# 라이브러리 설정
+find_package(GTest REQUIRED)
+message("GTest_INCLUDE_DIRS = ${GTest_INCLUDE_DIRS}")
+
+add_library(common_library set_avl.cc)
+
 # 실행 파일 설정
 # 실행 파일명은 main으로 설정
-add_executable (main main.cc set_avl.cc)
+add_executable (main main.cc)
+target_link_libraries(main common_library)
+
+add_executable(unitTestRunner test_runner.cc)
+target_link_libraries(unitTestRunner common_library ${GTEST_LIBRARIES})

--- a/set.h
+++ b/set.h
@@ -26,7 +26,7 @@ public:
     virtual int Find(const int key) = 0;
 
     // num을 삽입하고 해당 node의 depth를 출력
-    virtual void Insert(const int num) = 0;
+    virtual int Insert(const int num) = 0;
 
     // Advanced 기능
     // 해당 key를 가지고 있는 node의 depth와 rank를 출력

--- a/set_avl.cc
+++ b/set_avl.cc
@@ -60,7 +60,7 @@ int SetAVL::findDepth(NodeAVL *node, int key, int depth)
 }
 
 // num을 삽입하고 해당 node의 depth를 출력
-void SetAVL::Insert(const int num)
+int SetAVL::Insert(const int num)
 {
     if (root_ == nullptr)
     {
@@ -73,7 +73,7 @@ void SetAVL::Insert(const int num)
 
         // 새로 삽입한 node의 depth 출력
         // root node의 depth는 0으로 정의
-        std::cout << "0\n";
+        return 0;
     }
     else
     {
@@ -88,7 +88,7 @@ void SetAVL::Insert(const int num)
                 // 삽입하려고 하는 원소가 이미 Set에 들어있음
                 // new_node 메모리 해제
                 delete new_node;
-                break;
+                return -1;
             }
             else if (num < current_node->GetNum())
             {
@@ -115,9 +115,8 @@ void SetAVL::Insert(const int num)
                     // balance factor의 절댓값이 2 이상인 경우 Restructuring을 진행
                     Restructuring(new_node);
 
-                    // 새로 삽입한 node의 depth 출력
-                    std::cout << getDepth(new_node) << "\n";
-                    break;
+                    // 새로 삽입한 node의 depth를 return
+                    return getDepth(new_node);
                 }
                 else
                 {
@@ -151,9 +150,8 @@ void SetAVL::Insert(const int num)
                     // balance factor의 절댓값이 2 이상인 경우 Restructuring을 진행
                     Restructuring(new_node);
 
-                    // 새로 삽입한 node의 depth 출력
-                    std::cout << getDepth(new_node) << "\n";
-                    break;
+                    // 새로 삽입한 node의 depth를 return
+                    return getDepth(new_node);
                 }
                 else
                 {

--- a/set_avl.h
+++ b/set_avl.h
@@ -31,7 +31,7 @@ public:
     int Find(const int key) override final;
 
     // num을 삽입하고 해당 node의 depth를 출력
-    void Insert(const int num) override final;
+    int Insert(const int num) override final;
 
     // Advanced 기능
     // 해당 key를 가지고 있는 node의 depth와 rank를 출력

--- a/test_runner.cc
+++ b/test_runner.cc
@@ -1,0 +1,47 @@
+// 라이선스
+
+#include "set_avl.h"
+
+#include <gtest/gtest.h>
+#include <iostream>
+
+class SetAVLTestFixture : public testing::Test 
+{
+public:
+    SetAVLTestFixture() {}
+    virtual ~SetAVLTestFixture() {}
+    void SetUp() override { std::cout << "Test Start\n"; }
+    void TearDown() override {}
+protected:
+    SetAVL set_;
+};
+
+// 테스트케이스 1
+TEST_F(SetAVLTestFixture, SetAVLTest1)
+{
+    ASSERT_EQ(0, set_.Insert(38));
+    ASSERT_EQ(1, set_.Insert(58));
+    ASSERT_EQ(1, set_.Insert(31));
+    ASSERT_EQ(2, set_.Insert(27));
+    ASSERT_EQ(2, set_.Insert(68));
+    ASSERT_EQ(2, set_.Insert(81));
+    ASSERT_EQ(2, set_.Insert(14));
+    ASSERT_EQ(3, set_.Insert(76));
+    ASSERT_EQ(2, set_.Insert(78));
+    ASSERT_EQ(3, set_.Insert(37));
+    ASSERT_EQ(2, set_.Insert(34));
+}
+
+// 테스트케이스 2
+TEST_F(SetAVLTestFixture, SetAVLTest2)
+{
+    ASSERT_EQ(0, set_.Insert(1));
+    ASSERT_EQ(1, set_.Insert(2));
+    ASSERT_EQ(1, set_.Insert(3));
+}
+
+int main()
+{
+    testing::InitGoogleTest();
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- feature/#33

🌱 작업한 내용
- 구글테스트 환경 구축
- test_runner.cc에서 아래와 같은 코드를 통해 테스트케이스를 생성
```cpp
TEST_F(SetAVLTestFixture, SetAVLTest) // SetAVLTest는 테스트케이스 이름이며 임의로 설정할 수 있음
{
    ASSERT_EQ(0, set_.Insert(38)); // set_.Insert(38)의 return 값이 0과 일치하는지 확인
    ASSERT_EQ(1, set_.Insert(58)); // set_.Insert(58)의 return 값이 1과 일치하는지 확인
    ...
}
```
- 아래와 같이 명령어를 입력하여 구글테스트를 실행 (프로젝트 루트 디렉터리에서 입력)
```terminal
cd build
cmake ..
make
./unitTestRunner
```
- **Insert()** 함수의 return type을 void에서 **int**로 변경

## 📸 스크린샷

![20231206 구글테스트 사용법](https://github.com/OpenSourceProgramming/INHA_OSAP_004_Froyo/assets/79794123/c5d7cced-ea6c-4e6e-8538-3849b7dc7752)

## 📮 관련 이슈
- Resolved: #33
