### PR TITLE
chore: 라이선스 주석 추가 (#41)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,14 @@
+#####################################################
+# Copyright INHA_OSAP_004_Froyo
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+#
+# Contributors: Lee Seung-Bin
+# Latest Updated on 2023-12-06
+#####################################################
+
 # CMake 프로그램의 최소 버전
 cmake_minimum_required(VERSION 3.11)
 

--- a/node.h
+++ b/node.h
@@ -1,4 +1,13 @@
-// 라이선스
+/**************************************************
+ * Copyright INHA_OSAP_004_Froyo
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE file or at
+ * https://opensource.org/licenses/MIT.
+ *
+ * Contributors: Lee Seung-Bin
+ * Latest Updated on 2023-11-23
+**************************************************/
 
 #ifndef NODE_H
 #define NODE_H

--- a/node_avl.h
+++ b/node_avl.h
@@ -1,4 +1,13 @@
-// 라이선스
+/**************************************************
+ * Copyright INHA_OSAP_004_Froyo
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE file or at
+ * https://opensource.org/licenses/MIT.
+ *
+ * Contributors: Lee Seung-Bin
+ * Latest Updated on 2023-11-23
+**************************************************/
 
 #ifndef NODE_AVL_H
 #define NODE_AVL_H

--- a/set.h
+++ b/set.h
@@ -1,4 +1,13 @@
-// 라이선스
+/**************************************************
+ * Copyright INHA_OSAP_004_Froyo
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE file or at
+ * https://opensource.org/licenses/MIT.
+ *
+ * Contributors: Lee Seung-Bin
+ * Latest Updated on 2023-12-06
+**************************************************/
 
 #ifndef SET_H
 #define SET_H

--- a/set_avl.cc
+++ b/set_avl.cc
@@ -1,4 +1,13 @@
-// 라이선스
+/**************************************************
+ * Copyright INHA_OSAP_004_Froyo
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE file or at
+ * https://opensource.org/licenses/MIT.
+ *
+ * Contributors: Lee Seung-Bin, Choi Yi-Joon, Majunliang, Lee Jin-Woo
+ * Latest Updated on 2023-12-07
+**************************************************/
 
 #include "set_avl.h"
 

--- a/set_avl.h
+++ b/set_avl.h
@@ -1,4 +1,13 @@
-// 라이선스
+/**************************************************
+ * Copyright INHA_OSAP_004_Froyo
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE file or at
+ * https://opensource.org/licenses/MIT.
+ *
+ * Contributors: Lee Seung-Bin
+ * Latest Updated on 2023-12-06
+**************************************************/
 
 #ifndef SET_AVL_H
 #define SET_AVL_H

--- a/test_runner.cc
+++ b/test_runner.cc
@@ -1,4 +1,13 @@
-// 라이선스
+/**************************************************
+ * Copyright INHA_OSAP_004_Froyo
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE file or at
+ * https://opensource.org/licenses/MIT.
+ *
+ * Contributors: Lee Seung-Bin
+ * Latest Updated on 2023-12-06
+**************************************************/
 
 #include "set_avl.h"
 


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- feature/#41

🌱 작업한 내용
- 아래의 파일에 대하여 라이선스 주석 추가
    - CMakeLists.txt
    - node_avl.h
    - node.h
    - set_avl.cc
    - set_avl.h
    - set.h
    - test_runner.cc

## 📸 스크린샷

![20231208 라이선스 주석](https://github.com/OpenSourceProgramming/INHA_OSAP_004_Froyo/assets/79794123/d60697ef-2ca8-4646-9491-278553c8a445)

## 📮 관련 이슈
- Resolved: #41
