### PR TITLE
feat: 자식이 없는 경우 해당 노드 삭제 (#44)

### DIFF
--- a/set_avl.cc
+++ b/set_avl.cc
@@ -764,7 +764,7 @@ void SetAVL::RestructuringForRightRightCase(
 // node를 삭제 (node의 자식이 없는 경우)
 void SetAVL::EraseNodeThatHasNoChild(NodeAVL* node)
 {
-    
+    delete node;
 }
 
 // node를 삭제 (node의 자식이 1개만 있는 경우)


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- feature/#44

🌱 작업한 내용
- 삭제하려는 노드의 자식이 없는 경우에는 단순히 해당 노드의 삭제만을 진행합니다.

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|메인 테스트 화면|![image](https://github.com/OpenSourceProgramming/INHA_OSAP_004_Froyo/assets/69078056/ac350333-d201-4e25-91b5-b25ba38ec88f)|

## 📮 관련 이슈
- CC: #이슈번호
