### PR TITLE
feat: Erase 기능 구현 (삭제하려고 하는 노드의 자식이 2개일 경우) (#47)

### DIFF
--- a/node_avl.h
+++ b/node_avl.h
@@ -6,7 +6,7 @@
  * https://opensource.org/licenses/MIT.
  *
  * Contributors: Lee Seung-Bin
- * Latest Updated on 2023-11-23
+ * Latest Updated on 2023-12-14
 **************************************************/
 
 #ifndef NODE_AVL_H
@@ -27,6 +27,7 @@ public:
         parent_(nullptr), left_(nullptr), 
         right_(nullptr) {}
     ~NodeAVL() {}
+    void SetNum(const int num) { num_ = num; }
     void SetParent(NodeAVL* parent) { parent_ = parent; }
     void SetHeight(const int height) { height_ = height; }
     void SetLeft(NodeAVL* left) { left_ = left; }

--- a/set_avl.h
+++ b/set_avl.h
@@ -6,7 +6,7 @@
  * https://opensource.org/licenses/MIT.
  *
  * Contributors: Lee Seung-Bin
- * Latest Updated on 2023-12-06
+ * Latest Updated on 2023-12-14
 **************************************************/
 
 #ifndef SET_AVL_H
@@ -107,6 +107,12 @@ private:
 
     // node를 삭제 (node의 자식이 2개 있는 경우)
     void EraseNodeThatHasTwoChildren(NodeAVL* node);
+
+    // node의 successor를 찾음
+    NodeAVL* FindSuccessor(NodeAVL* node);
+
+    // Erase 기능을 수행할 때 필요에 따라 Restructuring을 진행함
+    void RestructuringForErase(NodeAVL* node);
 };
 
 #endif


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- feature/#47

🌱 작업한 내용
- num_에 대한 Setter 함수 추가
- FindSuccessor() 함수 구현
    - 어떤 노드의 successor를 구해서 return하는 함수
    - 삭제하려고 하는 노드의 자식이 2개일 때 successor 노드를 찾을 때 사용
- RestructuringForErase(NodeAVL* node) 함수 구현
    - 매개 변수로 들어온 node부터 루트 노드까지 balance factor를 계산하고 절댓값이 2 이상일 경우 restructuring을 수행함
    - 기존의 Restructuring() 함수와는 다르게 grand_parent_node가 먼저 결정되고 parent_node, child_node를 결정함
    - parent_node의 두 자식의 height가 같을 경우 single rotation을 수행하도록 child_node를 결정함 (923 ~ 945번 line 참조)
- EraseNodeThatHasTwoChildren() 함수 구현
    - 삭제하려고 하는 노드의 key 값을 successor의 key 값으로 대체함
    - successor를 삭제함
    - UpdateHeightUntilRoot() 함수를 통해 successor의 부모 노드부터 루트 노드까지 height를 갱신함
    - RestructuringForErase() 함수를 통해 필요에 따라 restructuring을 수행함

## 📮 관련 이슈
- Resolved: #47
